### PR TITLE
Update CERN license link

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,7 +3,7 @@
 Copyright 2017 QWERTY Embedded Design, LLC
 
 Licensed under CERN OHL v.2
-http://ohwr.org/cernohl
+https://www.ohwr.org/licenses/cern-ohl/license_versions/v1.2
 
 CERN Open Hardware Licence v1.2 
 

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Copyright 2017 QWERTY Embedded Design, LLC<br>
 Michael Welling <mwelling@ieee.org><br>
 
 LoFive is licensed under CERN Open Hardware Licence v1.2<br>
-[License Information](http://ohwr.org/cernohl)
+[License Information](https://www.ohwr.org/licenses/cern-ohl/license_versions/v1.2)
 


### PR DESCRIPTION
Current link goes to 404.